### PR TITLE
Symbol package publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
               run: |
                   $OutputDir = "nuget-packages"
                   New-Item -ItemType Directory -Force -Path $OutputDir
-                  Get-ChildItem -Path . -Recurse -Filter *.nupkg | Copy-Item -Destination $OutputDir
+                  Get-ChildItem -Path . -Recurse -Include *.nupkg,*.snupkg | Copy-Item -Destination $OutputDir
 
             - name: Upload NuGet packages as artifacts
               uses: actions/upload-artifact@v4
@@ -71,3 +71,4 @@ jobs:
                   NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
               run: |
                   dotnet nuget push ./nuget-packages/*.nupkg --api-key $NUGET_API_KEY --source https://api.nuget.org/v3/index.json
+                  dotnet nuget push ./nuget-packages/*.snupkg --api-key $NUGET_API_KEY --source https://api.nuget.org/v3/index.json

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
     build:
-        runs-on: windows-latest
+        runs-on: ubuntu-latest
 
         steps:
             - name: Checkout code

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -21,6 +21,8 @@
 		<PackageTags>http server lightweight self-contained sse iot desktop tools diagnostics</PackageTags>
 		<IncludeSymbols>true</IncludeSymbols>
 		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
+		<EmbedUntrackedSources>true</EmbedUntrackedSources>
+		<ContinuousIntegrationBuild Condition="'$(ContinuousIntegrationBuild)'=='' and '$(CI)'!=''">true</ContinuousIntegrationBuild>
 		
 		<!-- General build properties -->
 		<Nullable>enable</Nullable>

--- a/version.json
+++ b/version.json
@@ -9,9 +9,9 @@
         "^refs/heads/release/\\d+(?:\\.\\d+)?$"
     ],
     "cloudBuild": {
-        "setAllVariables": true,
+        "setAllVariables": false,
         "buildNumber": {
-            "enabled": true
+            "enabled": false
         }
     },
     "release": {


### PR DESCRIPTION
This PR configures the project for symbol package publishing to NuGet by adding support for .snupkg symbol packages and optimizing the CI build configuration.

- Enables symbol package creation and publishing with proper source embedding
- Updates CI pipeline to run on Ubuntu and handle both .nupkg and .snupkg files
- Optimizes build configuration by disabling unnecessary cloud build features