### PR TITLE
Add GuardHandler for basic request filtering and DI extensions

### DIFF
--- a/Yllibed.HttpServer.Tests/GenericDiHandlersFixture.cs
+++ b/Yllibed.HttpServer.Tests/GenericDiHandlersFixture.cs
@@ -1,0 +1,70 @@
+namespace Yllibed.HttpServer.Tests;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Yllibed.HttpServer.Extensions;
+using Yllibed.HttpServer.Handlers;
+
+[TestClass]
+public class GenericDiHandlersFixture : FixtureBase
+{
+	private sealed class EchoOptions
+	{
+		public string? Message { get; set; }
+	}
+
+	private sealed class EchoHandler : IHttpHandler
+	{
+		private readonly string _message;
+		public EchoHandler(IOptions<EchoOptions> options)
+		{
+			_message = options.Value.Message ?? "(null)";
+		}
+
+		public Task HandleRequest(CancellationToken ct, IHttpServerRequest request, string relativePath)
+		{
+			if (string.Equals(relativePath, "/echo", StringComparison.OrdinalIgnoreCase))
+			{
+				request.SetResponse("text/plain", _message);
+			}
+			return Task.CompletedTask;
+		}
+	}
+
+	[TestMethod]
+	public async Task AddHttpHandlerAndRegister_RegistersSimpleHandler()
+	{
+		var services = new ServiceCollection();
+		services.AddYllibedHttpServer(_ => { });
+
+		// Register a simple preconfigured StaticHandler via DI factory and ensure generic method can still wire it:
+		services.AddSingleton(new StaticHandler("/ping", "text/plain", "pong"));
+		services.AddHttpHandlerAndRegister<StaticHandler>(); // Remove the duplicate call
+
+		using var sp = services.BuildServiceProvider();
+		var server = sp.GetRequiredService<Server>();
+		var (uri4, _) = server.Start();
+
+		using var client = new HttpClient();
+		var res = await client.GetAsync(new Uri(uri4, "/ping"), CT).ConfigureAwait(false);
+		res.StatusCode.Should().Be(HttpStatusCode.OK);
+		(await res.Content.ReadAsStringAsync(CT).ConfigureAwait(false)).Should().Be("pong");
+	}
+
+	[TestMethod]
+	public async Task AddHttpHandlerAndRegister_WithOptions_ConfiguresAndRegisters()
+	{
+		var services = new ServiceCollection();
+		services.AddYllibedHttpServer(_ => { });
+		services.AddHttpHandlerAndRegister<EchoHandler, EchoOptions>(o => o.Message = "hello from options");
+
+		using var sp = services.BuildServiceProvider();
+		var server = sp.GetRequiredService<Server>();
+		var (uri4, _) = server.Start();
+
+		using var client = new HttpClient();
+		var res = await client.GetAsync(new Uri(uri4, "/echo"), CT).ConfigureAwait(false);
+		res.StatusCode.Should().Be(HttpStatusCode.OK);
+		(await res.Content.ReadAsStringAsync(CT).ConfigureAwait(false)).Should().Be("hello from options");
+	}
+}

--- a/Yllibed.HttpServer.Tests/GuardHandlerDiFixture.cs
+++ b/Yllibed.HttpServer.Tests/GuardHandlerDiFixture.cs
@@ -1,0 +1,36 @@
+namespace Yllibed.HttpServer.Tests;
+
+using Microsoft.Extensions.DependencyInjection;
+using Yllibed.HttpServer.Extensions;
+using Yllibed.HttpServer.Handlers;
+
+[TestClass]
+public class GuardHandlerDiFixture : FixtureBase
+{
+	[TestMethod]
+	public async Task AddGuardHandlerAndRegister_RegistersIntoServerPipeline()
+	{
+		var services = new ServiceCollection();
+		services.AddYllibedHttpServer();
+		services.AddGuardHandlerAndRegister(opts =>
+		{
+			opts.AllowedMethods = new[] { "GET" };
+		});
+
+		using var sp = services.BuildServiceProvider();
+		var server = sp.GetRequiredService<Server>();
+		server.RegisterHandler(new StaticHandler("/ok", "text/plain", "OK"));
+		var (uri4, _) = server.Start();
+
+		var requestUri = new Uri(uri4, "/ok");
+
+		using var client = new HttpClient();
+		// DELETE should be blocked by protection without manually resolving the handler
+		var blocked = await client.SendAsync(new HttpRequestMessage(HttpMethod.Delete, requestUri), CT).ConfigureAwait(false);
+		blocked.StatusCode.Should().Be(HttpStatusCode.MethodNotAllowed);
+
+		// GET passes
+		var allowed = await client.GetAsync(requestUri, CT).ConfigureAwait(false);
+		allowed.StatusCode.Should().Be(HttpStatusCode.OK);
+	}
+}

--- a/Yllibed.HttpServer.Tests/GuardHandlerFixture.cs
+++ b/Yllibed.HttpServer.Tests/GuardHandlerFixture.cs
@@ -1,0 +1,146 @@
+namespace Yllibed.HttpServer.Tests;
+
+using Yllibed.HttpServer.Handlers;
+
+[TestClass]
+public class GuardHandlerFixture : FixtureBase
+{
+	[TestMethod]
+	public async Task GuardHandler_UrlTooLong_Returns414()
+	{
+		using var sut = new Server();
+		// Very small limit for test
+		sut.RegisterHandler(new GuardHandler(maxUrlLength: 10));
+		sut.RegisterHandler(new StaticHandler("ok", "text/plain", "OK"));
+
+		var (uri4, _) = sut.Start();
+		var longPath = new string('a', 50);
+		var requestUri = new Uri(uri4, $"{longPath}");
+
+		using var client = new HttpClient();
+		var response = await client.GetAsync(requestUri, CT).ConfigureAwait(false);
+		response.StatusCode.Should().Be(HttpStatusCode.RequestUriTooLong);
+	}
+
+	[TestMethod]
+	public async Task GuardHandler_ContentLengthTooLarge_Returns413()
+	{
+		using var sut = new Server();
+		// Limit to 16 bytes
+		sut.RegisterHandler(new GuardHandler(maxBodyBytes: 16));
+		sut.RegisterHandler(new StaticHandler("ok", "text/plain", "OK"));
+
+		var (uri4, _) = sut.Start();
+		var requestUri = new Uri(uri4, "ok");
+
+		using var client = new HttpClient();
+		var content = new string('x', 100); // > 16 bytes
+		var response = await client.PostAsync(requestUri, new StringContent(content), CT).ConfigureAwait(false);
+		response.StatusCode.Should().Be(HttpStatusCode.RequestEntityTooLarge);
+	}
+
+	[TestMethod]
+	public async Task GuardHandler_HeadersTooLarge_Returns431()
+	{
+		using var sut = new Server();
+		// Keep overall header size tiny to force 431
+		sut.RegisterHandler(new GuardHandler(maxHeadersTotalSize: 100));
+		sut.RegisterHandler(new StaticHandler("ok", "text/plain", "OK"));
+
+		var (uri4, _) = sut.Start();
+		var requestUri = new Uri(uri4, "ok");
+
+		using var client = new HttpClient();
+		var msg = new HttpRequestMessage(HttpMethod.Get, requestUri);
+		msg.Headers.Add("X-Long", new string('z', 1024));
+		var response = await client.SendAsync(msg, CT).ConfigureAwait(false);
+		response.StatusCode.Should().Be((HttpStatusCode)431);
+	}
+	[TestMethod]
+	public async Task GuardHandler_MethodNotAllowed_Returns405()
+	{
+		using var sut = new Server();
+		sut.RegisterHandler(new GuardHandler(allowedMethods: new[] { "GET" }));
+		sut.RegisterHandler(new StaticHandler("/ok", "text/plain", "OK"));
+
+		var (uri4, _) = sut.Start();
+		var requestUri = new Uri(uri4, "/ok");
+
+		using var client = new HttpClient();
+		var response = await client.SendAsync(new HttpRequestMessage(HttpMethod.Delete, requestUri), CT).ConfigureAwait(false);
+		response.StatusCode.Should().Be(HttpStatusCode.MethodNotAllowed);
+	}
+
+	[TestMethod]
+	public async Task GuardHandler_ForbiddenHost_Returns403()
+	{
+		using var sut = new Server();
+		sut.RegisterHandler(new GuardHandler(allowedHosts: new[] { "localhost" }));
+		sut.RegisterHandler(new StaticHandler("/ok", "text/plain", "OK"));
+
+		var (uri4, _) = sut.Start();
+		var requestUri = new Uri(uri4, "/ok");
+
+		using var client = new HttpClient();
+		var msg = new HttpRequestMessage(HttpMethod.Get, requestUri);
+		// Force a different Host header value to trigger 403: use machine name if not localhost
+		msg.Headers.Host = "example.com";
+		var response = await client.SendAsync(msg, CT).ConfigureAwait(false);
+		response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+	}
+
+	[TestMethod]
+	public async Task GuardHandler_TooManyHeaders_Returns431()
+	{
+		using var sut = new Server();
+		// Set very low header count limit to trigger 431 (Host header alone is 1; we'll add another)
+		sut.RegisterHandler(new GuardHandler(maxHeadersCount: 1));
+		sut.RegisterHandler(new StaticHandler("/ok", "text/plain", "OK"));
+
+		var (uri4, _) = sut.Start();
+		var requestUri = new Uri(uri4, "/ok");
+
+		using var client = new HttpClient();
+		var msg = new HttpRequestMessage(HttpMethod.Get, requestUri);
+		msg.Headers.Add("X-One", "1");
+		var response = await client.SendAsync(msg, CT).ConfigureAwait(false);
+		response.StatusCode.Should().Be((HttpStatusCode)431);
+	}
+
+	[TestMethod]
+	public async Task GuardHandler_PassesThrough_ToNextHandler_WhenValid()
+	{
+		using var sut = new Server();
+		sut.RegisterHandler(new GuardHandler(allowedMethods: new[] { "GET" }));
+		sut.RegisterHandler(new StaticHandler("/ok", "text/plain", "OK"));
+
+		var (uri4, _) = sut.Start();
+		var requestUri = new Uri(uri4, "/ok");
+
+		using var client = new HttpClient();
+		var response = await client.GetAsync(requestUri, CT).ConfigureAwait(false);
+		response.StatusCode.Should().Be(HttpStatusCode.OK);
+  (await response.Content.ReadAsStringAsync(CT).ConfigureAwait(false)).Should().Be("OK");
+	}
+
+	[TestMethod]
+	public async Task GuardHandler_AsWrapper_CallsInnerOnlyOnPass()
+	{
+		using var sut = new Server();
+		var inner = new StaticHandler("/ok", "text/plain", "OK");
+		var guard = new GuardHandler(allowedMethods: new[] { "GET" }, inner: inner);
+		sut.RegisterHandler(guard);
+
+		var (uri4, _) = sut.Start();
+		var requestUri = new Uri(uri4, "/ok");
+
+		using var client = new HttpClient();
+		// DELETE should be blocked by protection and inner should not run
+		var blocked = await client.SendAsync(new HttpRequestMessage(HttpMethod.Delete, requestUri), CT).ConfigureAwait(false);
+		blocked.StatusCode.Should().Be(HttpStatusCode.MethodNotAllowed);
+
+		// GET should pass and inner returns OK
+		var allowed = await client.GetAsync(requestUri, CT).ConfigureAwait(false);
+		allowed.StatusCode.Should().Be(HttpStatusCode.OK);
+	}
+}

--- a/Yllibed.HttpServer/Extensions/GuardExtensions.cs
+++ b/Yllibed.HttpServer/Extensions/GuardExtensions.cs
@@ -1,0 +1,62 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Yllibed.HttpServer.Handlers;
+
+namespace Yllibed.HttpServer.Extensions;
+
+/// <summary>
+/// Extensions to configure GuardHandler via Microsoft DI.
+/// </summary>
+public static class GuardExtensions
+{
+	/// <summary>
+	/// Registers GuardHandler with options support and exposes it as both its concrete type and as IHttpHandler.
+	/// </summary>
+	public static IServiceCollection AddGuardHandler(this IServiceCollection services)
+	{
+		services.AddSingleton<GuardHandler>(sp => new GuardHandler(sp.GetRequiredService<IOptions<GuardHandler.Options>>()));
+		services.AddSingleton<IHttpHandler>(sp => sp.GetRequiredService<GuardHandler>());
+		return services;
+	}
+
+	/// <summary>
+	/// Registers GuardHandler with configuration delegate.
+	/// </summary>
+	public static IServiceCollection AddGuardHandler(this IServiceCollection services, Action<GuardHandler.Options> configure)
+	{
+		services.Configure(configure);
+		return services.AddGuardHandler();
+	}
+
+	/// <summary>
+	/// Registers GuardHandler and automatically registers it into the Server pipeline.
+	/// This avoids having to resolve the handler manually just to call Server.RegisterHandler.
+	/// </summary>
+	public static IServiceCollection AddGuardHandlerAndRegister(this IServiceCollection services, Action<GuardHandler.Options>? configure = null)
+	{
+		if (configure != null)
+		{
+			services.Configure(configure);
+		}
+		services.AddGuardHandler();
+		// Register a singleton that wires the handler into the server on construction
+		services.AddSingleton<GuardRegistration>();
+		return services;
+	}
+
+	private sealed class GuardRegistration : IDisposable
+	{
+		private readonly IDisposable _registration;
+
+		public GuardRegistration(Server server, GuardHandler handler)
+		{
+			// Place first by registering now; Server keeps order of registration
+			_registration = server.RegisterHandler(handler);
+		}
+
+		public void Dispose()
+		{
+			_registration.Dispose();
+		}
+	}
+}

--- a/Yllibed.HttpServer/Extensions/ServiceCollectionExtensions.cs
+++ b/Yllibed.HttpServer/Extensions/ServiceCollectionExtensions.cs
@@ -1,5 +1,9 @@
+using System;
+using System.Collections.Generic;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
+using Yllibed.HttpServer.Handlers;
 
 namespace Yllibed.HttpServer.Extensions;
 
@@ -15,7 +19,14 @@ public static class ServiceCollectionExtensions
 	/// <returns>The service collection for chaining.</returns>
 	public static IServiceCollection AddYllibedHttpServer(this IServiceCollection services)
 	{
-		services.AddSingleton<Server>(sp => new Server(sp.GetRequiredService<IOptions<ServerOptions>>()));
+		services.TryAddSingleton<HandlerRegistrationService>();
+		services.TryAddSingleton<Server>(sp =>
+		{
+			var server = new Server(sp.GetRequiredService<IOptions<ServerOptions>>());
+			var registrationService = sp.GetRequiredService<HandlerRegistrationService>();
+			registrationService.RegisterHandlers(server, sp);
+			return server;
+		});
 		return services;
 	}
 
@@ -28,7 +39,66 @@ public static class ServiceCollectionExtensions
 	public static IServiceCollection AddYllibedHttpServer(this IServiceCollection services, Action<ServerOptions> configureOptions)
 	{
 		services.Configure(configureOptions);
-		services.AddSingleton<Server>(sp => new Server(sp.GetRequiredService<IOptions<ServerOptions>>()));
+		return services.AddYllibedHttpServer();
+	}
+
+	/// <summary>
+	/// Generic: registers a handler THandler and automatically wires it into the Server pipeline.
+	/// The handler is resolved from DI and registered when the ServiceProvider is built; disposal unregisters it.
+	/// </summary>
+	public static IServiceCollection AddHttpHandlerAndRegister<THandler>(this IServiceCollection services)
+		where THandler : class, IHttpHandler
+	{
+		// Ensure handler is registered
+		services.TryAddSingleton<THandler>();
+
+		// Ensure the HandlerRegistrationService exists
+		services.TryAddSingleton<HandlerRegistrationService>();
+
+		// Register this handler type to be auto-registered
+		services.Configure<HandlerRegistrationOptions>(options =>
+		{
+			options.HandlerTypes.Add(typeof(THandler));
+		});
+
 		return services;
+	}
+
+	/// <summary>
+	/// Generic with options: configures TOptions and registers THandler that consumes IOptions&lt;TOptions&gt; (if applicable),
+	/// and auto-wires it into the Server pipeline. This removes the need to resolve it manually for registration.
+	/// </summary>
+	public static IServiceCollection AddHttpHandlerAndRegister<THandler, TOptions>(this IServiceCollection services, Action<TOptions> configure)
+		where THandler : class, IHttpHandler
+		where TOptions : class, new()
+	{
+		services.Configure(configure);
+		return services.AddHttpHandlerAndRegister<THandler>();
+	}
+
+	private sealed class HandlerRegistrationOptions
+	{
+		public List<Type> HandlerTypes { get; } = new();
+	}
+
+	private sealed class HandlerRegistrationService
+	{
+		private readonly IOptions<HandlerRegistrationOptions> _options;
+		private readonly List<IDisposable> _registrations = new();
+
+		public HandlerRegistrationService(IOptions<HandlerRegistrationOptions> options)
+		{
+			_options = options;
+		}
+
+		public void RegisterHandlers(Server server, IServiceProvider serviceProvider)
+		{
+			foreach (var handlerType in _options.Value.HandlerTypes)
+			{
+				var handler = (IHttpHandler)serviceProvider.GetRequiredService(handlerType);
+				var registration = server.RegisterHandler(handler);
+				_registrations.Add(registration);
+			}
+		}
 	}
 }

--- a/Yllibed.HttpServer/Handlers/GuardHandler.cs
+++ b/Yllibed.HttpServer/Handlers/GuardHandler.cs
@@ -60,7 +60,7 @@ public sealed class GuardHandler : IHttpHandler
 		MaxHeadersCount = maxHeadersCount;
 		MaxHeadersTotalSize = maxHeadersTotalSize;
 		MaxBodyBytes = maxBodyBytes;
-		_allowedMethods = allowedMethods != null ? new HashSet<string>(allowedMethods.Select(m => m.ToUpperInvariant()), StringComparer.OrdinalIgnoreCase) : null;
+		_allowedMethods = allowedMethods != null ? new HashSet<string>(allowedMethods, StringComparer.OrdinalIgnoreCase) : null;
 		_allowedHosts = allowedHosts != null ? new HashSet<string>(allowedHosts, StringComparer.OrdinalIgnoreCase) : null;
 		RequireHostHeader = requireHostHeader;
 		_inner = inner;
@@ -138,11 +138,11 @@ public sealed class GuardHandler : IHttpHandler
 				{
 					// Approximate header size as key length + sum of values length
 					total += kvp.Key.Length;
-					foreach (var v in kvp.Value)
+					total += kvp.Value.Sum(v => v?.Length ?? 0);
+					if (total > maxSize)
 					{
-						total += v?.Length ?? 0;
+						break;
 					}
-					if (total > maxSize) break;
 				}
 				if (total > maxSize)
 				{
@@ -162,7 +162,7 @@ public sealed class GuardHandler : IHttpHandler
 		// 4) If wrapping another handler, pass-through
 		if (_inner is not null)
 		{
-			await _inner.HandleRequest(ct, request, relativePath).ConfigureAwait(true);
+			await _inner.HandleRequest(ct, request, relativePath);
 		}
 	}
 

--- a/Yllibed.HttpServer/Handlers/GuardHandler.cs
+++ b/Yllibed.HttpServer/Handlers/GuardHandler.cs
@@ -1,0 +1,173 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Options;
+
+namespace Yllibed.HttpServer.Handlers;
+
+/// <summary>
+/// A basic request guard that performs best-effort filtering of incoming requests,
+/// rejecting them early when violating basic limits (URL length, headers size/count, payload size, etc.).
+/// This provides lightweight filtering against unsophisticated attacks, not comprehensive security.
+/// Place it first in the pipeline. Can optionally wrap an inner handler (next).
+/// </summary>
+public sealed class GuardHandler : IHttpHandler
+{
+	public sealed class Options
+	{
+		public int? MaxUrlLength { get; set; } = 2048;
+		public int? MaxHeadersCount { get; set; } = 100;
+		public int? MaxHeadersTotalSize { get; set; } = 32 * 1024;
+		public int? MaxBodyBytes { get; set; } = 10 * 1024 * 1024;
+		public string[]? AllowedMethods { get; set; } = new[] { "GET", "POST" };
+		public string[]? AllowedHosts { get; set; } = null; // null = any
+		public bool RequireHostHeader { get; set; } = true;
+	}
+
+	public int? MaxUrlLength { get; }
+	public int? MaxHeadersCount { get; }
+	public int? MaxHeadersTotalSize { get; }
+	public int? MaxBodyBytes { get; }
+	public bool RequireHostHeader { get; }
+
+	private readonly HashSet<string>? _allowedMethods;
+	private readonly HashSet<string>? _allowedHosts;
+	private readonly IHttpHandler? _inner;
+
+	/// <summary>
+	/// Create a new GuardHandler with optional limits. Null means no limit for that dimension.
+	/// Defaults are conservative and can be adjusted per app needs.
+	/// </summary>
+	/// <param name="maxUrlLength">Max allowed length of Path (including query). Default 2048.</param>
+	/// <param name="maxHeadersCount">Max allowed number of request headers. Default 100.</param>
+	/// <param name="maxHeadersTotalSize">Max cumulative size of header keys+values (characters). Default 32k.</param>
+	/// <param name="maxBodyBytes">Max payload size from Content-Length. Default 10 MB.</param>
+	/// <param name="allowedMethods">Optional allowed HTTP methods (case-insensitive). Null = any.</param>
+	/// <param name="allowedHosts">Optional allowed Host header values (case-insensitive). Null = any.</param>
+	/// <param name="requireHostHeader">Require Host header to be present (default true).</param>
+	/// <param name="inner">Optional inner (next) handler to call when checks pass.</param>
+	public GuardHandler(
+		int? maxUrlLength = 2048,
+		int? maxHeadersCount = 100,
+		int? maxHeadersTotalSize = 32 * 1024,
+		int? maxBodyBytes = 10 * 1024 * 1024,
+		IEnumerable<string>? allowedMethods = null,
+		IEnumerable<string>? allowedHosts = null,
+		bool requireHostHeader = true,
+		IHttpHandler? inner = null)
+	{
+		MaxUrlLength = maxUrlLength;
+		MaxHeadersCount = maxHeadersCount;
+		MaxHeadersTotalSize = maxHeadersTotalSize;
+		MaxBodyBytes = maxBodyBytes;
+		_allowedMethods = allowedMethods != null ? new HashSet<string>(allowedMethods.Select(m => m.ToUpperInvariant()), StringComparer.OrdinalIgnoreCase) : null;
+		_allowedHosts = allowedHosts != null ? new HashSet<string>(allowedHosts, StringComparer.OrdinalIgnoreCase) : null;
+		RequireHostHeader = requireHostHeader;
+		_inner = inner;
+	}
+
+	/// <summary>
+	/// DI-friendly constructor using Microsoft.Extensions.Options.IOptions.
+	/// </summary>
+	[Microsoft.Extensions.DependencyInjection.ActivatorUtilitiesConstructor]
+	public GuardHandler(Microsoft.Extensions.Options.IOptions<Options> options)
+		: this(
+			options?.Value?.MaxUrlLength,
+			options?.Value?.MaxHeadersCount,
+			options?.Value?.MaxHeadersTotalSize,
+			options?.Value?.MaxBodyBytes,
+			options?.Value?.AllowedMethods,
+			options?.Value?.AllowedHosts,
+			options?.Value?.RequireHostHeader ?? true,
+			inner: null)
+	{
+	}
+
+	public async Task HandleRequest(CancellationToken ct, IHttpServerRequest request, string relativePath)
+	{
+		// 0) Method allow-list
+		if (_allowedMethods is { Count: > 0 })
+		{
+			var method = request.Method?.ToUpperInvariant() ?? string.Empty;
+			if (!_allowedMethods.Contains(method))
+			{
+				Reject(request, 405, "METHOD NOT ALLOWED", System.FormattableString.Invariant($"Method '{request.Method}' not allowed"));
+				return;
+			}
+		}
+
+		// 0.1) Host header presence and allow-list
+		if (RequireHostHeader && string.IsNullOrWhiteSpace(request.Host))
+		{
+			Reject(request, 400, "BAD REQUEST", "Missing Host header");
+			return;
+		}
+		if (_allowedHosts is { Count: > 0 } && request.Host is { Length: > 0 } host)
+		{
+			// Compare case-insensitively on full Host header (can include port)
+			var allowed = _allowedHosts.Contains(host)
+				|| (request.HostName is { Length: > 0 } hn && _allowedHosts.Contains(hn));
+			if (!allowed)
+			{
+				Reject(request, 403, "FORBIDDEN", "Host not allowed");
+				return;
+			}
+		}
+
+		// 1) URL length (Path already includes querystring per IHttpServerRequest contract)
+		if (MaxUrlLength is int maxUrl && request.Path is { Length: > 0 } path && path.Length > maxUrl)
+		{
+			Reject(request, 414, "URI TOO LONG", System.FormattableString.Invariant($"URI too long (limit: {maxUrl} chars)"));
+			return;
+		}
+
+		// 2) Headers count / total size
+		var headers = request.Headers;
+		if (headers != null)
+		{
+			if (MaxHeadersCount is int maxCount && headers.Count > maxCount)
+			{
+				Reject(request, 431, "REQUEST HEADER FIELDS TOO LARGE", System.FormattableString.Invariant($"Too many headers (limit: {maxCount})"));
+				return;
+			}
+
+			if (MaxHeadersTotalSize is int maxSize)
+			{
+				var total = 0;
+				foreach (var kvp in headers)
+				{
+					// Approximate header size as key length + sum of values length
+					total += kvp.Key.Length;
+					foreach (var v in kvp.Value)
+					{
+						total += v?.Length ?? 0;
+					}
+					if (total > maxSize) break;
+				}
+				if (total > maxSize)
+				{
+					Reject(request, 431, "REQUEST HEADER FIELDS TOO LARGE", System.FormattableString.Invariant($"Headers too large (limit: {maxSize} chars)"));
+					return;
+				}
+			}
+		}
+
+		// 3) Payload (uses Content-Length when provided; chunked transfer isn't supported by this server)
+		if (MaxBodyBytes is int maxBody && request.ContentLength is int len && len > maxBody)
+		{
+			Reject(request, 413, "PAYLOAD TOO LARGE", System.FormattableString.Invariant($"Payload too large (limit: {maxBody} bytes)"));
+			return;
+		}
+
+		// 4) If wrapping another handler, pass-through
+		if (_inner is not null)
+		{
+			await _inner.HandleRequest(ct, request, relativePath).ConfigureAwait(true);
+		}
+	}
+
+	private static void Reject(IHttpServerRequest request, uint status, string reason, string message)
+	{
+		request.SetResponse("text/plain", message, status, reason);
+	}
+}


### PR DESCRIPTION
- Introduced `GuardHandler` for lightweight filtering of requests with configurable constraints
- Added DI-friendly extensions to register and auto-wire `GuardHandler` into the server.