### PR TITLE
chore(deps): add net10.0 to TargetFrameworks and solve NU1510 warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,11 @@ jobs:
               uses: actions/setup-dotnet@v3
               with:
                   dotnet-version: '9.0'
+            
+            - name: Setup .NET 10.0
+              uses: actions/setup-dotnet@v3
+              with:
+                  dotnet-version: '10.0'
 
             - name: Build
               run: dotnet build Yllibed.HttpServer.slnx /p:Configuration=Release

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,6 +13,5 @@
     <PackageVersion Include="PolySharp" Version="1.15.0" />
     <PackageVersion Include="System.Collections.Immutable" Version="9.0.8" />
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="9.0.8" />
-    <PackageVersion Include="System.ValueTuple" Version="4.6.1" />
   </ItemGroup>
 </Project>

--- a/Yllibed.HttpServer.Json.Tests/Yllibed.HttpServer.Json.Tests.csproj
+++ b/Yllibed.HttpServer.Json.Tests/Yllibed.HttpServer.Json.Tests.csproj
@@ -3,6 +3,9 @@
 		<TargetFrameworks>net9.0;net10.0</TargetFrameworks>
 		<IsTestProject>true</IsTestProject>
 		<ImplicitUsings>enable</ImplicitUsings>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(TargetFramework)'!='net10.0'">
 		<NoWarn>NU1510</NoWarn>
 	</PropertyGroup>
 
@@ -17,15 +20,17 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Microsoft.Extensions.Logging" />
-		<PackageReference Include="System.Diagnostics.DiagnosticSource" />
 		<PackageReference Include="System.ValueTuple" />
 		<PackageReference Update="Microsoft.NET.Test.Sdk" VersionOverride="17.14.1" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)'!='net10.0'">
+		<PackageReference Include="System.Diagnostics.DiagnosticSource" />
 	</ItemGroup>
 
 	<ItemGroup>
 	  <ProjectReference Include="..\Yllibed.HttpServer.Json\Yllibed.HttpServer.Json.csproj" />
 	  <ProjectReference Include="..\Yllibed.HttpServer\Yllibed.HttpServer.csproj" />
-
 	  <Compile Include="..\Yllibed.HttpServer.Tests\SseTestClient.cs" Link="Shared\SseTestClient.cs" />
 	</ItemGroup>
 </Project>

--- a/Yllibed.HttpServer.Json.Tests/Yllibed.HttpServer.Json.Tests.csproj
+++ b/Yllibed.HttpServer.Json.Tests/Yllibed.HttpServer.Json.Tests.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="MSTest.Sdk/3.10.4">
 	<PropertyGroup>
-		<TargetFrameworks>net9.0</TargetFrameworks>
+		<TargetFrameworks>net9.0;net10.0</TargetFrameworks>
 		<IsTestProject>true</IsTestProject>
 		<ImplicitUsings>enable</ImplicitUsings>
+		<NoWarn>NU1510</NoWarn>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Yllibed.HttpServer.Json.Tests/Yllibed.HttpServer.Json.Tests.csproj
+++ b/Yllibed.HttpServer.Json.Tests/Yllibed.HttpServer.Json.Tests.csproj
@@ -5,10 +5,6 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 	</PropertyGroup>
 
-	<PropertyGroup Condition="'$(TargetFramework)'!='net10.0'">
-		<NoWarn>NU1510</NoWarn>
-	</PropertyGroup>
-
 	<ItemGroup>
 		<PackageReference Include="AwesomeAssertions" />
 		<PackageReference Include="coverlet.collector">
@@ -20,12 +16,7 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Microsoft.Extensions.Logging" />
-		<PackageReference Include="System.ValueTuple" />
 		<PackageReference Update="Microsoft.NET.Test.Sdk" VersionOverride="17.14.1" />
-	</ItemGroup>
-
-	<ItemGroup Condition="'$(TargetFramework)'!='net10.0'">
-		<PackageReference Include="System.Diagnostics.DiagnosticSource" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Yllibed.HttpServer.Json/Yllibed.HttpServer.Json.csproj
+++ b/Yllibed.HttpServer.Json/Yllibed.HttpServer.Json.csproj
@@ -1,5 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
+		<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
 		<PackageId>Yllibed.HttpServer.Json</PackageId>
 		<Title>Yllibed HttpServer Json Adapter</Title>
 		<Product>Yllibed HttpServer Json Adapter</Product>

--- a/Yllibed.HttpServer.Tests/Yllibed.HttpServer.Tests.csproj
+++ b/Yllibed.HttpServer.Tests/Yllibed.HttpServer.Tests.csproj
@@ -4,17 +4,8 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 	</PropertyGroup>
 
-	<PropertyGroup Condition="'$(TargetFramework)'!='net10.0'">
-		<NoWarn>NU1510</NoWarn>
-	</PropertyGroup>
-
 	<ItemGroup>
 		<ProjectReference Include="..\Yllibed.HttpServer\Yllibed.HttpServer.csproj" />
-	</ItemGroup>
-
-	<ItemGroup Condition="'$(TargetFramework)'!='net10.0'">
-		<PackageReference Include="System.Diagnostics.DiagnosticSource" />
-		<PackageReference Include="System.ValueTuple" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Yllibed.HttpServer.Tests/Yllibed.HttpServer.Tests.csproj
+++ b/Yllibed.HttpServer.Tests/Yllibed.HttpServer.Tests.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="MSTest.Sdk/3.10.4">
 	<PropertyGroup>
-		<TargetFrameworks>net9.0</TargetFrameworks>
+		<TargetFrameworks>net9.0;net10.0</TargetFrameworks>
 		<ImplicitUsings>enable</ImplicitUsings>
+		<NoWarn>NU1510</NoWarn>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Yllibed.HttpServer.Tests/Yllibed.HttpServer.Tests.csproj
+++ b/Yllibed.HttpServer.Tests/Yllibed.HttpServer.Tests.csproj
@@ -2,11 +2,19 @@
 	<PropertyGroup>
 		<TargetFrameworks>net9.0;net10.0</TargetFrameworks>
 		<ImplicitUsings>enable</ImplicitUsings>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(TargetFramework)'!='net10.0'">
 		<NoWarn>NU1510</NoWarn>
 	</PropertyGroup>
 
 	<ItemGroup>
 		<ProjectReference Include="..\Yllibed.HttpServer\Yllibed.HttpServer.csproj" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)'!='net10.0'">
+		<PackageReference Include="System.Diagnostics.DiagnosticSource" />
+		<PackageReference Include="System.ValueTuple" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -19,8 +27,6 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="System.Diagnostics.DiagnosticSource" />
-		<PackageReference Include="System.ValueTuple" />
 		<PackageReference Update="Microsoft.NET.Test.Sdk" VersionOverride="17.14.1" />
 	</ItemGroup>
 </Project>

--- a/Yllibed.HttpServer/Yllibed.HttpServer.csproj
+++ b/Yllibed.HttpServer/Yllibed.HttpServer.csproj
@@ -11,6 +11,9 @@
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 
 		<InternalsVisibleTo>$(InternalsVisibleTo);Yllibed.HttpServer.Json;Yllibed.HttpServer.Tests</InternalsVisibleTo>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(TargetFramework)'!='net10.0'">
 		<NoWarn>NU1510</NoWarn>
 	</PropertyGroup>
 

--- a/Yllibed.HttpServer/Yllibed.HttpServer.csproj
+++ b/Yllibed.HttpServer/Yllibed.HttpServer.csproj
@@ -1,5 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
+		<TargetFrameworks>netstandard2.0;net8.0;net9.0;net10.0</TargetFrameworks>
 		<PackageId>Yllibed.HttpServer</PackageId>
 		<Title>Yllibed HttpServer</Title>
 		<Product>Yllibed HttpServer</Product>
@@ -10,6 +11,7 @@
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 
 		<InternalsVisibleTo>$(InternalsVisibleTo);Yllibed.HttpServer.Json;Yllibed.HttpServer.Tests</InternalsVisibleTo>
+		<NoWarn>NU1510</NoWarn>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -23,4 +25,5 @@
 		<PackageReference Include="System.Collections.Immutable" />
 		<PackageReference Include="System.ValueTuple" />
 	</ItemGroup>
+
 </Project>

--- a/Yllibed.HttpServer/Yllibed.HttpServer.csproj
+++ b/Yllibed.HttpServer/Yllibed.HttpServer.csproj
@@ -13,10 +13,6 @@
 		<InternalsVisibleTo>$(InternalsVisibleTo);Yllibed.HttpServer.Json;Yllibed.HttpServer.Tests</InternalsVisibleTo>
 	</PropertyGroup>
 
-	<PropertyGroup Condition="'$(TargetFramework)'!='net10.0'">
-		<NoWarn>NU1510</NoWarn>
-	</PropertyGroup>
-
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.Logging" />
 		<PackageReference Include="PolySharp" />
@@ -26,7 +22,5 @@
 
 	<ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
 		<PackageReference Include="System.Collections.Immutable" />
-		<PackageReference Include="System.ValueTuple" />
 	</ItemGroup>
-
 </Project>


### PR DESCRIPTION
1. **Added `net10.0` to all `TargetFrameworks` of Project files
2. **NU1510 remove Packages in Project files if not required for given Target Frameworks:**
    - Removed `System.ValueTuple` completly from Solution to get rid of the warning
 
      If this turns out to be required, the `NU1510` will need to be added as NoWarn.
      Tryed setting `NoWarn` or/and `PackageReference` Conditionally to TargetFramework but VS2026 kept Issuing it still
    
    - Removed `System.Diagnostics.DiagnosticSource` only from Projects (tests), which don't even target legacy `netstandard2.0`
    - local Build passed
    - Tests passed
 
> [!WARNING]
> netstandard2.0 seems to have no test coverage, alternative Validation options to consider?